### PR TITLE
Remove paste dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-paste = "0.1.18"
 
 [package.metadata.release]
 dev-version-ext             = "pre"


### PR DESCRIPTION
Replace paste with handwritten `$name:ident`, lowering compile times and removing the need to update it as dependency.